### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
     name: Build TypeScript
     runs-on: ubuntu-latest
     needs: [lint-and-format, test]
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/MouradiSalah/Express.ts/security/code-scanning/6](https://github.com/MouradiSalah/Express.ts/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the `Build TypeScript` job. The permissions should be set to the least privilege required for the job to function correctly. Since the job does not perform any repository write operations, the `contents: read` permission is sufficient.

The `permissions` block should be added directly under the job definition (`name: Build TypeScript`) in the `.github/workflows/ci.yml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
