### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   lint-and-format:
     name: Lint and Format Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/MouradiSalah/Express.ts/security/code-scanning/3](https://github.com/MouradiSalah/Express.ts/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `lint-and-format` job. This block will explicitly set the `contents` permission to `read`, which is the minimum required for the job to function correctly. This ensures that the job does not inherit potentially excessive permissions from the repository or workflow defaults.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
