### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/MouradiSalah/Express.ts/security/code-scanning/5](https://github.com/MouradiSalah/Express.ts/security/code-scanning/5)

To fix the issue, add a `permissions` block to the `test` job in the workflow file. The block should specify the least privileges required for the job to function correctly. Since the `test` job only needs to read repository contents, the permissions can be set to `contents: read`. This change ensures that the job does not inadvertently inherit higher permissions from the repository.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
